### PR TITLE
changing UID/GID for Fedora sysconfig

### DIFF
--- a/etc/sysconfig/pagekite.fedora
+++ b/etc/sysconfig/pagekite.fedora
@@ -1,4 +1,4 @@
 OPTIONS="--optdir=/etc/pagekite.d"
-PK_UID=daemon
-PK_GID=daemon
+PK_UID=pagekite
+PK_GID=pagekite
 PK_LOGFILE=/var/log/pagekite/pagekite.log


### PR DESCRIPTION
Hello,

I would like to open discussion about user for pagekite. The typical practice is to create special user for each service, because then you can control security better:
- you need to have 600 permissions with pagekite owner for 20_account.rc file (contains sensitive information)
- you do not want other processes to write into /var/log/pagekite

The question is if you want to have this upstream. I know you generate RPMs somehow, not sure if "daemon" is acceptable practice e.g. for SUSE... I can sed this in the Fedora SPEC file if you will not like this.
