### PR TITLE
removing incorrect macro in lapcat manpage

### DIFF
--- a/doc/lapcat.1
+++ b/doc/lapcat.1
@@ -50,8 +50,6 @@ In netcat mode, lapcat will connect to the remote host and relay data back
 and forth to the standard input and output.  This is similar to using the
 telnet or netcat tools.
 
-...
-
 .SH AUTHOR
 .P
 Written by Bjarni R. Einarsson <http://bre.klaki.net/> for The Beanstalks


### PR DESCRIPTION
Hey,

I see warnings in the rpmlint, what is this macro for? I am removing it, I guess this is a typo.
