### PR TITLE
Add PATCH to HTTP_METHODS and patch to HTTP_DANGER filter

### DIFF
--- a/pagekite/proto/filters.py
+++ b/pagekite/proto/filters.py
@@ -170,7 +170,7 @@ class HttpSecurityFilter(HttpHeaderFilter):
   """Filter that blocks known-to-be-dangerous requests."""
 
   DISABLE = 'trusted'
-  HTTP_DANGER = re.compile('(?ism)^((get|post|put|delete) '
+  HTTP_DANGER = re.compile('(?ism)^((get|post|put|patch|delete) '
                            # xampp paths, anything starting with /adm*
                            '((?:/+(?:xampp/|security/|licenses/|webalizer/|server-(?:status|info)|adm)'
                            '|[^\n]*/'

--- a/pagekite/proto/parsers.py
+++ b/pagekite/proto/parsers.py
@@ -26,7 +26,7 @@ import pagekite.logging as logging
 
 HTTP_METHODS = ['OPTIONS', 'CONNECT', 'GET', 'HEAD', 'POST', 'PUT', 'TRACE',
                 'PROPFIND', 'PROPPATCH', 'MKCOL', 'DELETE', 'COPY', 'MOVE',
-                'LOCK', 'UNLOCK', 'PING']
+                'LOCK', 'UNLOCK', 'PING', 'PATCH']
 HTTP_VERSIONS = ['HTTP/1.0', 'HTTP/1.1']
 
 


### PR DESCRIPTION
As mentioned in https://twitter.com/tanghus/status/443959708303773696

> @PageKite How come you block PATCH requests? It breaks ownCloud Contacts app from >= version 6 :(
