### PR TITLE
Add --domaindir option to support dynamic changes in frontend domain configuration

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os
 import runpy
 

--- a/doc/MANPAGE.md
+++ b/doc/MANPAGE.md
@@ -246,7 +246,13 @@ time the program defaults will Just Work.
      Accept tunneling requests for the named protocols and specified
      domain, using the given secret.  A * may be used as a wildcard for
      subdomains or protocols.
-
+	 
+   * <b>--domaindir</b>=`/path/to/directory` <br />
+	 Read --domain settings from `/path/to/directory/*.rc`, will
+ 	 update internal dictionary dynamically when files in this
+	 directory are added or removed and a connection is attempted
+	 by a backend.
+	 
    * <b>--authdomain</b>=`auth-domain`, <b>--authdomain</b>=`target-domain`:`auth-domain` <br />
      Use `auth-domain` as a remote authentication server for the
      DNS-based authetication protocol.  If no <i>target-domain</i>

--- a/doc/README.md
+++ b/doc/README.md
@@ -853,6 +853,34 @@ cases pagekite.py will report the actual remote IP in its own log.
 [ [up](#toc) ]
 
 
+<a                                                              name=ddir></a>
+### 2.13. Support for dynamic domains through --domaindir ###
+
+A frontend instance (started using the `--is-front-end`) can support changes in
+the configuration of the backends it allows connections to through the use of 
+the `--domaindir` option. This option can be used to specify the path to a 
+folder containing --domain specifications that may be changed during the life 
+of the frontend instance. 
+
+Calling the frontend will therefore look like this :
+
+    $ pagekite.py \
+      --is-front-end \
+  	  --domaindir=pathToYourDirectory
+	
+With the folder at "pathToYourDirectory" expected to contain the --domain 
+specifications corresponding to each backend that must be allowed to connect 
+to the frontend.
+
+The frontend will update its internal list of backends on  each connection 
+attempt of any backend, as long as the specified directory's timestamp changed. 
+The recommended way to do handle a changing domain list is to add a new file 
+when adding the configuration of a new backend, and to remove a file when 
+removing a backend.
+
+[ [up](#toc) ]
+
+
 <a                                                              name=lim></a>
 ## 3. Limitations, caveats and known bugs ##
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -33,6 +33,7 @@ you can run your own using pagekite.py.
       10. [Unix/Linux systems integration                  ](#unx)
       11. [Saving your configuration                       ](#cfg)
       12. [A word about security and logs                  ](#sec)
+      13. [Support for dynamic domains through --domaindir ](#ddir)
 
    3. [Limitations, caveats and known bugs                 ](#lim)
 

--- a/pagekite/__main__.py
+++ b/pagekite/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 This is the pagekite.py Main() function.
 """

--- a/pagekite/manual.py
+++ b/pagekite/manual.py
@@ -215,6 +215,12 @@ MAN_OPT_FRONTEND = ("""\
             Accept tunneling requests for the named protocols and specified
             domain, using the given secret.  A * may be used as a wildcard for
             subdomains or protocols.
+            
+    --domaindir</b>=<a>/path/to/directory</a> __
+            Read --domain settings from <tt>/path/to/directory/*.rc</tt>, will
+            update internal dictionary dynamically when files in this
+            directory are added or removed and a connection is attempted
+            by a backend.
 
     --authdomain</b>=<a>auth-domain</a>,\
  <b>--authdomain</b>=<a>target-domain</a>:<a>auth-domain</a> __


### PR DESCRIPTION
This is a feature proposed by my collegue Arnout Vandecappelle a few months ago - below is a copy of the commit message associated with the commit including the code corresponding to the new --domaindir option.

***

The new --domaindir option allows for a directory of domains to be
specified when calling the script. This option will only work if
the instance of the script is a frontend, i.e. if --isfrontend was
specified when starting the instance. In this case, the frontend
instance will look in the specified directory for --domain=
specifications and update its internal dictionary. Domains can be
added and removed dynamically during the life of the instance.

Backends that are already connected will not be closed by the
frontend on having their --domain line removed from the domain
directory, but will be rejected on future reconnections.

It is expected that the path specified through the --domaindir
option only contains files specifying --domain options. The
internal backend dictionary of the frontend instance will only be
updated on the next attempted connection from a backend instance,
and if the timestamp of the domain directory has been updated.
The recommended way to update the domain directory is therefore
either to use the "touch" Linux utility, or to only change the
directory through removal and creation of new files.

Since this option is implemented using the existing
ConfigureFromFile function, it may allow dynamical changes to any
configuration parameter of the instance, but only domains have
been tested and are supported through the above-specified usage
recommendations.