### PR TITLE
Support python3.8

### DIFF
--- a/pagekite/httpd.py
+++ b/pagekite/httpd.py
@@ -33,7 +33,10 @@ from six.moves.xmlrpc_server import SimpleXMLRPCServer, SimpleXMLRPCRequestHandl
 
 import base64
 import cgi
-from html import escape as escape_html
+try:
+  from html import escape as escape_html
+except ImportError:
+  from cgi import escape as escape_html
 import os
 import re
 import socket

--- a/pagekite/httpd.py
+++ b/pagekite/httpd.py
@@ -33,7 +33,7 @@ from six.moves.xmlrpc_server import SimpleXMLRPCServer, SimpleXMLRPCRequestHandl
 
 import base64
 import cgi
-from cgi import escape as escape_html
+from html import escape as escape_html
 import os
 import re
 import socket

--- a/pagekite/pk.py
+++ b/pagekite/pk.py
@@ -36,7 +36,10 @@ from six.moves.xmlrpc_server import SimpleXMLRPCServer, SimpleXMLRPCRequestHandl
 
 import base64
 import cgi
-from html import escape as escape_html
+try:
+  from html import escape as escape_html
+except ImportError:
+  from cgi import escape as escape_html
 import errno
 import gc
 import getopt

--- a/pagekite/pk.py
+++ b/pagekite/pk.py
@@ -36,7 +36,7 @@ from six.moves.xmlrpc_server import SimpleXMLRPCServer, SimpleXMLRPCRequestHandl
 
 import base64
 import cgi
-from cgi import escape as escape_html
+from html import escape as escape_html
 import errno
 import gc
 import getopt

--- a/pagekite/proto/conns.py
+++ b/pagekite/proto/conns.py
@@ -1261,7 +1261,7 @@ class UserConn(Selectable):
   def __html__(self):
     return ('<b>Tunnel</b>: <a href="/conn/%s">%s</a><br>'
             '%s') % (self.tunnel and self.tunnel.sid or '',
-                     escape_html('%s' % (self.tunnel or ''), quote=False),
+                     escape_html('%s' % (self.tunnel or ''), quote=False) if PY3 else escape_html('%s' % (self.tunnel or '')),
                      Selectable.__html__(self))
 
   def IsReadable(self, now):

--- a/pagekite/proto/conns.py
+++ b/pagekite/proto/conns.py
@@ -1261,7 +1261,7 @@ class UserConn(Selectable):
   def __html__(self):
     return ('<b>Tunnel</b>: <a href="/conn/%s">%s</a><br>'
             '%s') % (self.tunnel and self.tunnel.sid or '',
-                     escape_html('%s' % (self.tunnel or '')),
+                     escape_html('%s' % (self.tunnel or ''), quote=False),
                      Selectable.__html__(self))
 
   def IsReadable(self, now):


### PR DESCRIPTION
Per https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals, cgi.escape has been removed in python3.8 and has been depreciated since python3.2. This commit replaces cgi.escape with html.escape which should fix the package on python3.8. Fixes #76.