### PR TITLE
Fix python3 support (exception syntax in pagekite/proto/conns.py)

### DIFF
--- a/pagekite/proto/conns.py
+++ b/pagekite/proto/conns.py
@@ -2160,15 +2160,16 @@ class Listener(Selectable):
         self.HandleClient(client, address)
       self.sstate = (self.dead and 'dead' or 'idle')
       return True
-    except IOError, err:
+    except IOError as err:
       self.sstate += '/ioerr=%s' % (err.errno,)
       self.LogDebug('Listener::ReadData: error: %s (%s)' % (err, err.errno))
 
-    except socket.error, (errno, msg):
+    except socket.error as e:
+      (errno, msg) = e.args
       self.sstate += '/sockerr=%s' % (errno,)
       self.LogInfo('Listener::ReadData: error: %s (errno=%s)' % (msg, errno))
 
-    except Exception, e:
+    except Exception as e:
       self.sstate += '/exc'
       self.LogDebug('Listener::ReadData: %s' % e)
 


### PR DESCRIPTION
Commit 7c04593 did not inherit from b8711b6, so the exceptions in the file `pagekite/proto/conns.py` used the old-style syntax (`except a, b:`) instead of the new-style syntax (`except a as b:`). This PR reapplies 7c04593 to `conns.py` which fixes the python3 support.
<hr>
I don't know how this project prefers to handle merging, so I cherry-picked b8711b6 into the most recent common ancestor of b8711b6 and 7c04593. The actual diff is only 4 lines, but I applied the commits this way so that the changes should stick around, even if some other branches are merged again. I can apply a simpler commit if you prefer though.
<details><summary>The commands that I used to apply the commit</summary>

```bash
git checkout $(git merge-base b8711b60793e895d7878da0d8b6021aabb5c9e69 7c04593ec42b7e78d5cc3d36616ecc389487682c)
git cherry-pick -n b8711b60793e895d7878da0d8b6021aabb5c9e69
git reset HEAD $(git diff --name-only --cached | grep -v 'pagekite/proto/conns.py')
git commit -m "Reapply b8711b"
git reset --hard HEAD
git checkout main
git merge d47acf5
# Fix merge conflicts
git add pagekite/proto/conns.py
git merge --continue
```
</details>