### PR TITLE
Fixed to work on android

### DIFF
--- a/pagekite/common.py
+++ b/pagekite/common.py
@@ -55,7 +55,8 @@ OS_CA_CERTS = (
   "/usr/local/share/certs/ca-root-nss.crt",  # FreeBSD/DragonFly
   "/usr/local/etc/openssl/cert.pem",         # OS X (Homebrew)
   "/opt/local/etc/openssl/cert.pem",         # OS X (Ports?)
-  "/system/etc/security/cacerts")            # Android
+#  "/system/etc/security/cacerts")            # Android # Shows IsADirectoryError
+  "/data/data/com.termux/files/usr/etc/tls/cert.pem")  # Android-Termux
 
 CURL_CA_CERTS = 'https://curl.haxx.se/ca/cacert.pem'
 

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -18,7 +18,9 @@ WARNING: You don't seem to have curl installed!
       Basic version:  https://pagekite.net/pk/pagekite.py
 
       Alpha GTK GUI:  https://pagekite.net/pk/pagekite-gtk.py
-       Android/SL4A:  https://pagekite.net/pk/pagekite-android.py
+       Android/SL4A:  https://pagekite.net/pk/pagekite-android.py #Not working
+       Android/SL4A:  https://raw.githubusercontent.com/Deshdeepak1/pagekite-android/master/pagekite.py
+       Recommended to replace https://pagekite.net/pk/pagekite.py file with above file.
 
   Remember to run 'chmod +x pagekite*.py' after downloading.
   There are also Debian and RPM packages on: https://pagekite.net/downloads/


### PR DESCRIPTION
The pagekite/common.py file has a directory as one element of ca_certs. I replaced it with a file location.
I also recommend to replace https://pagekite.net/pk/pagekite.py file with modified https://raw.githubusercontent.com/Deshdeepak1/pagekite-android/master/pagekite.py , so anyone can directly use pagekite on android particularly on termux app.
Everything else works same. 