### PR TITLE
Python3 fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for building combined pagekite.py files.
 export PYTHONPATH := .
 
-BREED_PAGEKITE = /usr/lib/python2.7/dist-packages/six.py \
+BREED_PAGEKITE = $(shell python -c 'import six; print(six.__file__)') \
                  pagekite/__init__.py \
 	         pagekite/common.py \
 	         pagekite/compat.py \

--- a/pagekite/proto/conns.py
+++ b/pagekite/proto/conns.py
@@ -1973,13 +1973,13 @@ class FastPingHelper(threading.Thread):
       _clients, self.clients = self.clients, []
     for ts, client, addr, handler in _clients:
       try:
-        data = client.recv(64, socket.MSG_PEEK)
+        data = s(client.recv(64, socket.MSG_PEEK))
       except:
         data = None
       try:
         if data:
           if '\nHost: ping.pagekite' in data:
-            client.send(self.rejection)
+            client.send(b(self.rejection))
             client.close()
             self.fast_pinged.append(obfuIp(addr[0]))
           else:

--- a/pagekite/proto/conns.py
+++ b/pagekite/proto/conns.py
@@ -1833,6 +1833,7 @@ class UnknownConn(MagicProtocolParser):
           self.conns.SetIdle(self, 120)
           return True
         else:
+          self.LogInfo("TLS unknown SNI host %s" % domains[0])
           self.Send(TLS_Unavailable(unavailable=True), try_flush=True)
           return False
 

--- a/pagekite/proto/proto.py
+++ b/pagekite/proto/proto.py
@@ -306,4 +306,4 @@ def TLS_Unavailable(forbidden=False, unavailable=False):
   # Unfortunately, Chrome/ium only honors code 49, any other code will
   # cause it to transparently retry with SSLv3. So although this is a
   # bit misleading, this is what we send...
-  return struct.pack('>BBBBBBB', 0x15, 3, 3, 0, 2, 2, 49) # 49 = Access denied
+  return s(struct.pack('>BBBBBBB', 0x15, 3, 3, 0, 2, 2, 49)) # 49 = Access denied

--- a/pagekite/proto/selectables.py
+++ b/pagekite/proto/selectables.py
@@ -459,7 +459,7 @@ class Selectable(object):
             sent = self.fd.send(send_buffer)
             if logging.DEBUG_IO:
               print(('==> OUT =[%s: %d/%d bytes]==(\n%s)=='
-                     ) % (self, sent, send_bytes, send_buffer[:min(320, sent)]))
+                     ) % (self, sent, send_bytes, repr(send_buffer[:min(320, sent)])))
             self.wrote_bytes += sent
             break
           except (SSL.WantWriteError, SSL.WantReadError) as err:

--- a/pagekite/proto/ws_abnf.py
+++ b/pagekite/proto/ws_abnf.py
@@ -241,11 +241,11 @@ class ABNF(object):
         elif length < ABNF.LENGTH_16:
             frame_header += chr(self.mask << 7 | 0x7e)
             frame_header = six.b(frame_header)
-            frame_header += struct.pack("!H", length)
+            frame_header += six.b(struct.pack("!H", length))
         else:
             frame_header += chr(self.mask << 7 | 0x7f)
             frame_header = six.b(frame_header)
-            frame_header += struct.pack("!Q", length)
+            frame_header += six.b(struct.pack("!Q", length))
 
         if not self.mask:
             return frame_header + self.data
@@ -319,12 +319,12 @@ class ABNF(object):
         if length_bits == 0x7e:
             if len(data) < 2:
                 raise WebSocketNeedMoreDataException()
-            self.length = struct.unpack("!H", data[:2])[0]
+            self.length = struct.unpack("!H", b(data[:2]))[0]
             return data[2:]
         elif length_bits == 0x7f:
             if len(data) < 8:
                 raise WebSocketNeedMoreDataException()
-            self.length = struct.unpack("!Q", data[:8])[0]
+            self.length = struct.unpack("!Q", b(data[:8]))[0]
             return data[8:]
         else:
             self.length = length_bits


### PR DESCRIPTION
Two fixes required for python3 support.

Tested with python2.7, python3.6 and python3.8.

(This PR replaces #96)