### PR TITLE
Add `tls_ciphers` option to allow specifiying custom ciphers list

### DIFF
--- a/pagekite/manual.py
+++ b/pagekite/manual.py
@@ -337,6 +337,15 @@ MAN_OPT_FRONTEND = ("""\
             Default name to use for SSL, if SNI (Server Name Indication)
             is missing from incoming HTTPS connections.
 
+    --tls_ciphers</b>=<a>cipher list</a> __
+            List of ciphers to use for front end server TLS sockets.
+            For example, Debian 11 and later may need <tt>DEFAULT@SECLEVEL=1</tt>
+            in order to allow TLSv1 connections from older embedded
+            backends. Make sure you know what you are doing when using this!
+
+    --tls_legacy   __Allow legacy TLS for front end servers.
+            Make sure you know what you are doing when using this!
+
     --tls_endpoint</b>=<a>name</a>:<a>/path/to/file</a> __
             Terminate SSL/TLS for a name using key/cert from a file.
 
@@ -355,7 +364,7 @@ MAN_OPT_SYSTEM = ("""\
     --savefile</b>=<a>/path/to/file</a> __
             Saved settings will be written to this file.
 
-    --save          __Save the current configuration to the savefile.
+    --save         __Save the current configuration to the savefile.
 
     --settings</b> __
             Dump the current settings to STDOUT, formatted as a configuration

--- a/pagekite/pk.py
+++ b/pagekite/pk.py
@@ -91,7 +91,7 @@ OPT_ARGS = ['noloop', 'clean', 'nopyopenssl', 'nossl', 'nocrashreport',
             'auththreads=', 'authdomain=', 'authfail_closed',
             'motd=', 'register=', 'host=', 'noupgradeinfo', 'upgradeinfo=',
             'ports=', 'protos=', 'portalias=', 'rawports=',
-            'tls_legacy', 'tls_default=', 'tls_endpoint=', 'selfsign',
+            'tls_legacy', 'tls_ciphers=', 'tls_default=', 'tls_endpoint=', 'selfsign',
             'fe_certname=', 'fe_nocertcheck', 'ca_certs=',
             'kitename=', 'kitesecret=',
             'backend=', 'define_backend=', 'be_config=',
@@ -1080,6 +1080,7 @@ class PageKite(object):
 
     self.tls_legacy = False
     self.tls_default = None
+    self.tls_ciphers = None
     self.tls_endpoints = {}
     self.fe_certname = []
     #
@@ -1555,6 +1556,7 @@ class PageKite(object):
         config.append('# tls_endpoint = DOMAIN:PEM_FILE')
       config.extend([
         p('tls_default = %s', self.tls_default, 'DOMAIN'),
+        p('tls_ciphers = %s', self.tls_ciphers, ''),
         p('tls_legacy = %s', self.tls_legacy, False),
         '',
       ])
@@ -2371,10 +2373,11 @@ class PageKite(object):
         self.ui_paths[host] = hosti
 
       elif opt == '--tls_default': self.tls_default = arg
+      elif opt == '--tls_ciphers': self.tls_ciphers = arg
       elif opt == '--tls_legacy': self.tls_legacy = True
       elif opt == '--tls_endpoint':
         name, pemfile = arg.split(':', 1)
-        ctx = socks.MakeBestEffortSSLContext(legacy=self.tls_legacy)
+        ctx = socks.MakeBestEffortSSLContext(legacy=self.tls_legacy, ciphers=self.tls_ciphers)
         ctx.use_privatekey_file(pemfile)
         ctx.use_certificate_chain_file(pemfile)
         self.tls_endpoints[name] = (pemfile, ctx)

--- a/pagekite_gtk.py
+++ b/pagekite_gtk.py
@@ -1,0 +1,1 @@
+scripts/pagekite_gtk


### PR DESCRIPTION
This is needed in particular when running pagekite.py as a frontend server on debian >=11, where the cipherlist must be set to `DEFAULT@SECLEVEL=1` to allow current (at the time of writing this) libpagekite embedded backends to connect, as these use TLSv1 even on platforms which do support TLSv2 and later.

Also, this PR adds a help text for `tls_legacy` (which existed, but was not listed in help so far)