### PR TITLE
Fix invalid escape sequences in strings

### DIFF
--- a/pagekite/common.py
+++ b/pagekite/common.py
@@ -150,7 +150,7 @@ DYNDNS = {
 
 # Create our service-domain matching regexp
 import re
-SERVICE_DOMAIN_RE = re.compile('\.(' + '|'.join(SERVICE_DOMAINS) + ')$')
+SERVICE_DOMAIN_RE = re.compile(r'\.(' + '|'.join(SERVICE_DOMAINS) + ')$')
 SERVICE_SUBDOMAIN_RE = re.compile(r'^([A-Za-z0-9_-]+\.)*[A-Za-z0-9_-]+$')
 
 

--- a/pagekite/pk.py
+++ b/pagekite/pk.py
@@ -1240,7 +1240,7 @@ class PageKite(object):
     return self.pyfile  # Fall back to distributed CA certs
 
   ACL_SHORTHAND = {
-    'localhost': '((::ffff:)?127\..*|::1)',
+    'localhost': r'((::ffff:)?127\..*|::1)',
     'any': '.*'
   }
   def CheckAcls(self, acls, address, which, conn=None):

--- a/pagekite/proto/filters.py
+++ b/pagekite/proto/filters.py
@@ -160,7 +160,7 @@ class HaproxyProtocolFilter(TunnelFilter):
 class HttpHeaderFilter(TunnelFilter):
   """Filter that adds X-Forwarded-For and X-Forwarded-Proto to requests."""
   FILTERS = ('data_in')
-  HTTP_HEADER = re.compile('(?ism)^(([A-Z]+) ([^\n]+) HTTP/\d+\.\d+\s*)$')
+  HTTP_HEADER = re.compile('(?ism)^(([A-Z]+) ([^\n]+) HTTP/\\d+\\.\\d+\\s*)$')
   DISABLE = 'rawheaders'
 
   def filter_data_in(self, tunnel, sid, data):
@@ -213,15 +213,15 @@ class HttpSecurityFilter(HttpHeaderFilter):
                            '((?:/+(?:xampp/|security/|licenses/|webalizer/|server-(?:status|info)|adm)'
                            '|[^\n]*/'
                              # WordPress admin pages
-                             '(?:wp-admin/(?!admin-ajax|css/)|wp-config\.php'
+                             r'(?:wp-admin/(?!admin-ajax|css/)|wp-config\.php'
                              # Hackzor tricks
-                             '|system32/|\.\.|\.ht(?:access|pass)'
+                             r'|system32/|\.\.|\.ht(?:access|pass)'
                              # phpMyAdmin and similar tools
                              '|(?:php|sql)?my(?:sql)?(?:adm|manager)'
                              # Setup pages for common PHP tools
-                             '|(?:adm[^\n]*|install[^\n]*|setup)\.php)'
+                             '|(?:adm[^\n]*|install[^\n]*|setup)\\.php)'
                            ')[^\n]*)'
-                           ' HTTP/\d+\.\d+\s*)$')
+                           r' HTTP/\d+\.\d+\s*)$')
   REJECT = 'PAGEKITE_REJECT_'
 
   def filter_header_data_in(self, http_hdr, data, info):

--- a/pagekite/proto/selectables.py
+++ b/pagekite/proto/selectables.py
@@ -653,7 +653,7 @@ class LineParser(Selectable):
 TLS_CLIENTHELLO = '%c' % 0o26
 SSL_CLIENTHELLO = '\x80'
 XML_PREAMBLE = '<?xml'
-XMPP_REGEXP = re.compile("<[^>]+\sto=([^\s>]+)[^>]*>")
+XMPP_REGEXP = re.compile(r"<[^>]+\sto=([^\s>]+)[^>]*>")
 
 class MagicProtocolParser(LineParser):
   """A Selectable which recognizes HTTP, TLS or XMPP preambles."""

--- a/pagekite/ui/basic.py
+++ b/pagekite/ui/basic.py
@@ -54,8 +54,8 @@ class BasicUi(NullUi):
   DAEMON_FRIENDLY = False
   WANTS_STDERR = True
   EMAIL_RE = re.compile(r'^[a-z0-9!#$%&\'\*\+\/=?^_`{|}~-]+'
-                         '(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@'
-                         '(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)*'
+                         '(?:\\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@'
+                         r'(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)*'
                          '(?:[a-zA-Z]{2,16})$')
   def Notify(self, message, prefix=' ',
              popup=False, color=None, now=None, alignright=''):

--- a/pagekite/ui/remote.py
+++ b/pagekite/ui/remote.py
@@ -43,8 +43,8 @@ class RemoteUi(NullUi):
   ALLOWS_INPUT = True
   WANTS_STDERR = True
   EMAIL_RE = re.compile(r'^[a-z0-9!#$%&\'\*\+\/=?^_`{|}~-]+'
-                         '(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@'
-                         '(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)*'
+                         '(?:\\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@'
+                         r'(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)*'
                          '(?:[a-zA-Z]{2,4}|museum)$')
 
   def __init__(self, welcome=None, wfile=sys.stderr, rfile=sys.stdin):


### PR DESCRIPTION
- In Python 3.12 and above, these lead to messages such as "SyntaxWarning: invalid escape sequence '\s'". In versions of Python earlier than 3.12, they were DeprecationWarnings. In a later version of Python these will lead to a SyntaxError.

Tests:

- Verify that the new strings are equivalent to the old strings by old_string == new_string in the python interpreter in Python 3.12. old_string throws SyntaxWarning new_string does not.

- Run 'python3 -m py_compile' on each python source file (except legacy files) and ensure that there are no syntax errors or warnings.