### PR TITLE
Add support for post authentication apps

### DIFF
--- a/doc/MANPAGE.md
+++ b/doc/MANPAGE.md
@@ -213,6 +213,8 @@ time the program defaults will Just Work.
      If authentication fails, reject tunnel requests. The default is
      to fail open and allow tunnels if the auth checks are broken.
 
+   * <b>--postauth</b>=`/path/to/app` <br />
+     Invoke an external application on successful tunnel authentication.
 
    * <b>--service_off</b>=`proto`:`kitename`:`host`:`port`:`secret` <br />
      Same as --service_on, except disabled by default.

--- a/pagekite/manual.py
+++ b/pagekite/manual.py
@@ -191,6 +191,8 @@ MAN_OPT_BACKEND = ("""\
             If authentication fails, reject tunnel requests. The default is
             to fail open and allow tunnels if the auth checks are broken.
 
+    --postauth</b>=<a>/path/to/app</a> __
+            Invoke an external application on successful tunnel authentication.
 
     --service_off</b>=<a>proto</a>:<a>kitename</a>:<a>host</a>:<a>port</a>:<a>secret</a> __
             Same as --service_on, except disabled by default.


### PR DESCRIPTION
In some cases, it can be useful to run actions when a pagekite backend has successfully authenticated.

To make it possible, add a '--postauth' option that, if provided, runs the script passed as an argument.